### PR TITLE
Prevent "String index is out of bounds" error

### DIFF
--- a/JSONPreview/JSONPreview/Core/JSONTextView.swift
+++ b/JSONPreview/JSONPreview/Core/JSONTextView.swift
@@ -68,7 +68,8 @@ extension JSONTextView {
         let startIndex = text.startIndex
         
         // Prevent the click logic from triggering when the line break is clicked.
-        guard text[text.index(startIndex, offsetBy: characterIndex)] != "\n" else { return }
+        let index = text.index(startIndex, offsetBy: characterIndex)
+        guard index < text.endIndex, text[index] != "\n" else { return }
         
         let callbackBlock = {
             self.clickDelegate?.textView(self, didClickZoomAt: point.y)


### PR DESCRIPTION
If you click on an empty line, an "String index is out of bounds" error is raised